### PR TITLE
Add support for building on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,38 @@
+version: 2
+jobs:
+  build:
+    branches:
+      only:
+        - master
+
+    docker:
+      - image: ssrg/popcorn-kernel:circleci-1.0
+
+    environment:
+      COMPILATION_LOGS: /tmp/compilation_logs
+
+    steps:
+      - checkout
+
+      - run: mkdir -p $COMPILATION_LOGS
+
+      - run:
+          name: Build x86_64
+          command: |
+            set +o pipefail
+            cp .config-qemu-x86_64 .config
+            make -j2 2>&1 | tee $COMPILATION_LOGS/x86_64.log
+
+      - run:
+          name: Build arm64
+          command: |
+            set +o pipefail
+            cp .config-qemu-arm64 .config
+            make -j2 2>&1 | tee $COMPILATION_LOGS/arm64.log
+          environment:
+            ARCH: arm64
+            CROSS_COMPILE: aarch64-linux-gnu-
+
+      - store_artifacts:
+          path: /tmp/compilation_logs
+          destination: raw-test-output


### PR DESCRIPTION
Add support for building the x86_64 and arm64 kernels on CircleCI. Only the
master branch will be built.

I can also add the source for the docker container if necessary.