### PR TITLE
Update TLS pointers according to userspace changes

### DIFF
--- a/arch/arm64/kernel/process_server.c
+++ b/arch/arm64/kernel/process_server.c
@@ -51,7 +51,7 @@ int save_thread_info(struct field_arch *arch)
 
 	cpu = get_cpu();
 
-	arch->tls = current->thread.tp_value;
+	asm("mrs %0, tpidr_el0;" : "=r"(arch->tls));
 	arch->fpu_active = test_thread_flag(TIF_FOREIGN_FPSTATE);
 
 	put_cpu();

--- a/kernel/popcorn/process_server.c
+++ b/kernel/popcorn/process_server.c
@@ -416,7 +416,7 @@ static void process_back_migration(back_migration_request_t *req)
 
 	/* mm is not updated here; has been synchronized through vma operations */
 
-	restore_thread_info(&req->arch, false);
+	restore_thread_info(&req->arch, true);
 
 out_free:
 	pcn_kmsg_done(req);


### PR DESCRIPTION
Enforcing a common thread pointer across architectures requires
extensive changes in the linker and C library.  Instead, userspace will
change the TLS pointer before a migration for the destination
architecture.  This commit makes the necessary kernel-side changes to
reflect TLS pointer changes from userspace across migrations.